### PR TITLE
feature(dashboard): band admin dashboard

### DIFF
--- a/harmonix/urls.py
+++ b/harmonix/urls.py
@@ -23,6 +23,7 @@ from accounts import views as account_views
 urlpatterns = [
     path('', views.landing_page, name='landing'),
     path('dashboard/musician/', account_views.musician_dashboard, name='musician_dashboard'),
+    path('dashboard/band-admin/', account_views.band_admin_dashboard, name='band_admin_dashboard'),
     path('listings/', include('listings.urls')),  # Listings CRUD functionality
     path('applications/', include('applications.urls')),  # Application management
     path('invitations/', include('invitations.urls')),  # Musician invitations

--- a/harmonix/views.py
+++ b/harmonix/views.py
@@ -6,7 +6,7 @@ def landing_page(request):
         if request.user.is_musician:
             return redirect('musician_dashboard')
         if request.user.is_band_admin:
-            return redirect('listings:feed')
+            return redirect('band_admin_dashboard')
         return redirect('listings:feed')
 
     return render(request, 'landing.html')

--- a/templates/components/navbar.html
+++ b/templates/components/navbar.html
@@ -6,7 +6,7 @@
             {% if user.is_authenticated and user.is_musician %}
                 {% url 'musician_dashboard' as dashboard_url %}
             {% elif user.is_authenticated and user.is_band_admin %}
-                {% url 'listings:feed' as dashboard_url %}
+                {% url 'band_admin_dashboard' as dashboard_url %}
             {% else %}
                 {% url 'landing' as dashboard_url %}
             {% endif %}
@@ -24,6 +24,13 @@
                 {% if user.is_authenticated and user.is_musician %}
                     <a href="{{ dashboard_url }}"
                        class="{% if 'dashboard/musician' in request.path %}text-[#4F2FC0] border-b-2 border-[#4F2FC0]{% else %}hover:text-[#4F2FC0]{% endif %} transition-colors pb-4 -mb-px">
+                        Dashboard
+                    </a>
+                {% endif %}
+
+                {% if user.is_authenticated and user.is_band_admin %}
+                    <a href="{{ dashboard_url }}"
+                       class="{% if 'dashboard/band-admin' in request.path %}text-[#4F2FC0] border-b-2 border-[#4F2FC0]{% else %}hover:text-[#4F2FC0]{% endif %} transition-colors pb-4 -mb-px">
                         Dashboard
                     </a>
                 {% endif %}

--- a/templates/dashboard/band_admin_dashboard.html
+++ b/templates/dashboard/band_admin_dashboard.html
@@ -1,0 +1,153 @@
+{% extends 'base.html' %}
+
+{% block title %}Band Admin Dashboard | Harmonix{% endblock %}
+
+{% block content %}
+<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+    <!-- Welcome Header -->
+    <div class="mb-6">
+        <h1 class="text-3xl font-bold text-gray-900">Welcome back, {{ request.user.username }}!</h1>
+        <p class="text-gray-500 mt-1">Manage your band listings and find the perfect musicians</p>
+    </div>
+
+    <!-- Stats Row -->
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+        <div class="bg-white rounded-lg border border-gray-200 p-5">
+            <p class="text-sm text-[#4F2FC0] font-medium">Active Listings</p>
+            <p class="text-4xl font-bold text-gray-900 mt-1">{{ stats.active_listings }}</p>
+            <p class="text-sm text-gray-500 mt-1">Open positions</p>
+        </div>
+        <div class="bg-white rounded-lg border border-gray-200 p-5">
+            <p class="text-sm text-[#4F2FC0] font-medium">Applications</p>
+            <p class="text-4xl font-bold text-gray-900 mt-1">{{ stats.applications_total }}</p>
+            <p class="text-sm text-yellow-800 mt-1">{{ stats.applications_pending }} pending review</p>
+        </div>
+        <div class="bg-white rounded-lg border border-gray-200 p-5">
+            <p class="text-sm text-gray-600 font-medium">Invitations Sent</p>
+            <p class="text-4xl font-bold text-gray-900 mt-1">{{ stats.invitations_sent }}</p>
+            <p class="text-sm text-gray-500 mt-1">Awaiting responses</p>
+        </div>
+    </div>
+
+    <!-- Quick Actions -->
+    <div class="bg-white rounded-lg border border-gray-200 p-5 mb-6">
+        <h2 class="text-lg font-semibold text-gray-900 mb-4">Quick Actions</h2>
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-3">
+            <a href="{% url 'listings:create' %}"
+               class="flex items-center justify-center gap-2 rounded-lg bg-[#4F2FC0] px-4 py-3 text-white font-medium hover:bg-[#3f24a0] transition">
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
+                </svg>
+                Create New Listing
+            </a>
+            <a href="{% url 'invitations:band_admin_invite' %}"
+               class="flex items-center justify-center gap-2 rounded-lg border border-gray-300 bg-white px-4 py-3 text-gray-700 font-medium hover:text-[#4F2FC0] transition">
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"/>
+                </svg>
+                Browse Musicians
+            </a>
+            <a href="{% url 'invitations:band_admin_invite' %}"
+               class="flex items-center justify-center gap-2 rounded-lg border border-gray-300 bg-white px-4 py-3 text-gray-700 font-medium hover:text-[#4F2FC0] transition">
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/>
+                </svg>
+                View Invitations
+            </a>
+        </div>
+    </div>
+
+    <!-- Recent Activity -->
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <!-- Your Active Listings -->
+        <div class="bg-white rounded-lg border border-gray-200 p-5">
+            <div class="flex items-center justify-between mb-4">
+                <h2 class="text-lg font-semibold text-gray-900">Your Active Listings</h2>
+                <a href="{% url 'listings:feed' %}" class="text-sm text-[#4F2FC0] font-medium hover:text-[#3f24a0] flex items-center gap-1">
+                    View all <span>→</span>
+                </a>
+            </div>
+            {% if recent_listings %}
+                <div class="space-y-3">
+                    {% for listing in recent_listings %}
+                        <div class="border border-gray-200 rounded-lg p-4">
+                            <a href="{% url 'listings:detail' pk=listing.pk %}" class="font-semibold text-gray-900 hover:text-[#4F2FC0] block truncate">{{ listing.title }}</a>
+                            <p class="text-sm text-gray-500 mt-1 line-clamp-2">{{ listing.description|truncatechars:50 }}</p>
+                            <div class="flex items-center gap-2 mt-3 flex-wrap">
+                                {% for genre in listing.genres_list %}
+                                    <span class="text-xs bg-gray-100 text-gray-600 px-2 py-1 rounded">{{ genre }}</span>
+                                {% endfor %}
+                                <span class="flex items-center gap-1 text-xs text-gray-400">
+                                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"/>
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"/>
+                                    </svg>
+                                    {{ listing.band_admin.location|default:"—" }}
+                                </span>
+                                <span class="flex items-center gap-1 text-xs text-gray-400">
+                                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19V6l12-3v13M9 19c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zm12-3c0 1.105-1.343 2-3 2s-3-.895-3-2 1.343-2 3-2 3 .895 3 2zM9 10l12-3"/>
+                                    </svg>
+                                    {% for instrument in listing.instruments_list %}{{ instrument }}{% if not forloop.last %}, {% endif %}{% endfor %}
+                                </span>
+                            </div>
+                            <div class="flex items-center gap-1 mt-2 text-xs text-gray-400">
+                                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/>
+                                </svg>
+                                Posted {{ listing.created_at|date:"M d" }}
+                            </div>
+                        </div>
+                    {% endfor %}
+                </div>
+            {% else %}
+                <div class="text-center py-8">
+                    <p class="text-gray-500">No active listings yet.</p>
+                    <a href="{% url 'listings:create' %}" class="text-[#4F2FC0] font-medium mt-2 inline-block">Create your first listing →</a>
+                </div>
+            {% endif %}
+        </div>
+
+        <!-- Recent Applications -->
+        <div class="bg-white rounded-lg border border-gray-200 p-5">
+            <div class="flex items-center justify-between mb-4">
+                <h2 class="text-lg font-semibold text-gray-900">Recent Applications</h2>
+                <a href="{% url 'applications:my_applications' %}" class="text-sm text-[#4F2FC0] font-medium hover:text-[#3f24a0] flex items-center gap-1">
+                    View all <span>→</span>
+                </a>
+            </div>
+            {% if recent_applications %}
+                <div class="space-y-3">
+                    {% for application in recent_applications %}
+                        <div class="border border-gray-200 rounded-lg p-4">
+                            <div class="flex items-start justify-between gap-2">
+                                <div class="flex-1 min-w-0">
+                                    <p class="font-semibold text-gray-900 truncate">{{ application.musician.username }}</p>
+                                    <p class="text-sm text-gray-500 truncate">Applied to: {{ application.listing.title }}</p>
+                                    {% if application.message %}
+                                        <p class="text-sm text-gray-600 mt-2">"{{ application.message|truncatechars:80 }}"</p>
+                                    {% endif %}
+                                    <div class="flex items-center gap-1 mt-2 text-xs text-gray-400">
+                                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/>
+                                        </svg>
+                                        {{ application.created_at|date:"M d" }}
+                                    </div>
+                                </div>
+                                <span class="text-xs font-medium px-3 py-1 rounded-full {{ application.status_class }}">
+                                    {{ application.get_status_display }}
+                                </span>
+                            </div>
+                        </div>
+                    {% endfor %}
+                </div>
+            {% else %}
+                <div class="text-center py-8">
+                    <p class="text-gray-500">No applications yet.</p>
+                    <a href="{% url 'listings:create' %}" class="text-[#4F2FC0] font-medium mt-2 inline-block">Create a listing to attract musicians →</a>
+                </div>
+            {% endif %}
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/dashboard/musician_dashboard.html
+++ b/templates/dashboard/musician_dashboard.html
@@ -71,10 +71,10 @@
                 <div class="space-y-3">
                     {% for application in recent_applications %}
                         <div class="border border-gray-200 rounded-lg p-4">
-                            <div class="flex items-start justify-between">
-                                <div class="flex-1">
-                                    <p class="font-semibold text-gray-900">{{ application.listing.title }}</p>
-                                    <p class="text-sm text-gray-500">{{ application.listing.band_name }}</p>
+                            <div class="flex items-start justify-between gap-2">
+                                <div class="flex-1 min-w-0">
+                                    <p class="font-semibold text-gray-900 truncate">{{ application.listing.title }}</p>
+                                    <p class="text-sm text-gray-500 truncate">{{ application.listing.band_name }}</p>
                                     <div class="flex items-center gap-3 mt-2 text-xs text-gray-400">
                                         <span class="flex items-center gap-1">
                                             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -118,9 +118,9 @@
                 <div class="space-y-3">
                     {% for invitation in recent_invitations %}
                         <div class="border border-gray-200 rounded-lg p-4">
-                            <div class="flex items-start justify-between">
-                                <div class="flex-1">
-                                    <p class="font-semibold text-gray-900">{{ invitation.listing.band_name }}</p>
+                            <div class="flex items-start justify-between gap-2">
+                                <div class="flex-1 min-w-0">
+                                    <p class="font-semibold text-gray-900 truncate">{{ invitation.listing.band_name }}</p>
                                     {% if invitation.message %}
                                         <p class="text-sm text-gray-600 mt-1">{{ invitation.message|truncatechars:80 }}</p>
                                     {% endif %}


### PR DESCRIPTION
- add band_admin_dashboard view with stats for listings, applications, invitations
- create band admin dashboard template matching musician dashboard layout
- wire /dashboard/band-admin/ route in urls.py
- update navbar to show Dashboard link for band admins
- redirect band admins to their dashboard on login and landing page
- fix text overflow in both dashboards with truncate classes